### PR TITLE
Added GB using a new Register that calls HMRC's VAT API - Fixed naming issues

### DIFF
--- a/pyvat/__init__.py
+++ b/pyvat/__init__.py
@@ -57,8 +57,11 @@ EU VAT number structures are retrieved from `VIES
 """
 
 VIES_REGISTRY = ViesRegistry()
-HMRC_REGISTRY = HMRCRegistry()
 """VIES registry instance.
+"""
+
+HMRC_REGISTRY = HMRCRegistry()
+"""HMRC registry instance.
 """
 
 VAT_REGISTRIES = {

--- a/pyvat/countries.py
+++ b/pyvat/countries.py
@@ -10,7 +10,7 @@ EU_COUNTRY_CODES = set([
     'ES',  # Spain.
     'FI',  # Finland.
     'FR',  # France.
-    'GB',  # United Kingdom.
+    'GB',  # Great Britain.
     'EL', 'GR',  # Greece.
     'HR',  # Croatia.
     'HU',  # Hungary.

--- a/pyvat/registries.py
+++ b/pyvat/registries.py
@@ -191,10 +191,8 @@ class HMRCRegistry(Registry):
     Uses the HMRC API for validating VAT numbers.
     """
 
-    CHECK_VAT_SERVICE_URL = 'https://api.service.hmrc.gov.uk/organisations/' \
-                            'vat/check-vat-number/lookup/'
-    CHECK_VAT_SERVICE_TEST_URL = 'https://test-api.service.hmrc.gov.uk/organisations/' \
-                                 'vat/check-vat-number/lookup/'
+    CHECK_VAT_SERVICE_URL = 'https://api.service.hmrc.gov.uk'
+    CHECK_VAT_SERVICE_TEST_URL = 'https://test-api.service.hmrc.gov.uk'
     """URL for the VAT checking service.
     """
 
@@ -209,11 +207,13 @@ class HMRCRegistry(Registry):
         result = VatNumberCheckResult()
         result.is_valid = False
         try:
-            url = self.CHECK_VAT_SERVICE_URL
+            base_url = self.CHECK_VAT_SERVICE_URL
             if self.access_token is None:
-                self._authenticate()
+                self._authenticate(test)
             if test:
-                url = self.CHECK_VAT_SERVICE_TEST_URL
+                base_url = self.CHECK_VAT_SERVICE_TEST_URL
+
+            url = "{0}/organisations/vat/check-vat-number/lookup/".format(base_url)
             headers = self._authentication_headers()
             response = requests.get(
                 url + vat_number,
@@ -221,7 +221,7 @@ class HMRCRegistry(Registry):
                 headers=headers
             )
             if response.status_code == 401:
-                self._authenticate()
+                self._authenticate(test)
                 headers = self._authentication_headers()
                 response = requests.get(url + vat_number,
                                  timeout=self.DEFAULT_TIMEOUT, headers=headers)
@@ -279,15 +279,16 @@ class HMRCRegistry(Registry):
                 result.business_address = business_address
         return result
 
-    def _authenticate(self):
+    def _authenticate(self, test):
         """Generate the token for the API."""
         url = self.CHECK_VAT_SERVICE_URL
         if test:
             url = self.CHECK_VAT_SERVICE_TEST_URL
         """Authenticates with the API and gets a token for subsequent requests."""
-        url = "{0}oauth/token".format(url)
+        url = "{0}/oauth/token".format(url)
         data = {
-            "grant_type": "read:vat",
+            "grant_type": "client_credentials",
+            "scope": "read:vat",
             "client_id": os.environ.get('PYVAT_UK_CLIENT_ID'),
             "client_secret": os.environ.get('PYVAT_UK_CLIENT_SECRET'),
         }
@@ -303,6 +304,7 @@ class HMRCRegistry(Registry):
         return {
             "Authorization": "Bearer " + self.access_token,
             "content-type": "application/json",
+            "Accept": "application/vnd.hmrc.2.0+json",
             "charset": "UTF-8",
         }
 

--- a/pyvat/vat_rules.py
+++ b/pyvat/vat_rules.py
@@ -244,7 +244,7 @@ class MtVatRules(ConstantEuVatRateRules):
 
 
 class GbVatRules(ConstantEuVatRateRules):
-    """VAT rules for United Kingdom.
+    """VAT rules for Great Britain.
     """
 
     def get_vat_rate(self, item_type):


### PR DESCRIPTION
I took back the issue #62 and fixed naming issues on it to unstuck it.
I also did some check and I think United Kingdom would be more accurate at it look like Northern Ireland seems to be inside that region (I can revert the name if you think it is necessary):
- The [United Kingdom](https://www.casita.com/student-accommodation/uk), commonly referred to as the UK, is a sovereign nation consisting of four constituent countries: England, Scotland, Wales, and Northern Ireland. https://www.casita.com/blog/the-difference-between-the-uk-great-britain-and-england
- Northern Ireland will remain aligned with the rest of the UK for VAT processes related to transactions in services. HMRC will continue to be responsible for the operation and collection of the revenues in Northern Ireland. https://www.gov.uk/government/publications/accounting-for-vat-on-goods-moving-between-great-britain-and-northern-ireland-from-1-january-2021 